### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,77 +1,61 @@
 **Enigmatic.js - Documentation**
 
-*Note: The code provided is a self-contained JavaScript file that defines a library named Enigmatic.js. The documentation below explains the functions and features available in the library.*
+*Note: This repository contains a single JavaScript file that exposes a small set of utility functions under the global `w` object.*
 
 **1. Introduction**
 
-Enigmatic.js is a JavaScript library designed to provide utility functions and tools to simplify common tasks such as loading resources, working with custom elements, managing state, and handling data reactivity. The library aims to enhance web development productivity and offers the following features:
+Enigmatic.js provides helpers for loading resources, creating custom elements and managing a small reactive state. The library automatically activates once the script is loaded and offers the following features:
 
-- Resource Loading: Load JavaScript and CSS files dynamically.
-- Custom Element: Define custom web components with ease.
-- State Management: Easily manage and react to changes in application state.
-- Data Handling: Fetch data from remote sources and stream real-time data.
+- Resource Loading: load JavaScript and CSS files dynamically.
+- Custom Elements: quickly define web components with built in event wiring.
+- State Management: update DOM elements automatically when state values change.
+- Data Handling: fetch JSON on elements with a `fetch` attribute and receive server-sent events via streams.
 
 **2. Helpers**
 
-Enigmatic.js provides several helper functions to simplify common tasks:
+Several helper functions simplify common tasks:
 
-- `w.$(selector)`: Returns the first element matching the given CSS selector within the document.
-- `w.$$(selector)`: Returns a list of all elements matching the given CSS selector within the document.
-- `w.loadJS(src)`: Loads a JavaScript file dynamically by creating a script element in the document's head.
-- `w.loadCSS(src)`: Loads a CSS file dynamically by creating a link element in the document's head.
-- `w.wait(ms)`: Returns a Promise that resolves after the specified number of milliseconds.
-- `w.ready()`: Returns a Promise that resolves when the DOM is ready and the document has completed loading.
+- `w.$(selector)`: return the first element matching the selector.
+- `w.$$(selector)`: return all elements matching the selector.
+- `w.loadJS(src)`: dynamically load a JavaScript file.
+- `w.loadCSS(src)`: dynamically load a CSS file.
+- `w.wait(ms)`: resolve a Promise after `ms` milliseconds.
+- `w.ready()`: resolve when the DOM is ready.
 
 **3. Template Flattening**
 
-Enigmatic.js provides the `w.flatten(obj, text)` function to template a string using placeholders. The placeholders can be in the form of `{$key}`, `{_key_}`, or `{_val_}`. The function recursively replaces the placeholders with the corresponding keys and values from the provided object.
+`w.flatten(obj, text)` replaces placeholders like `{key}` within a template string using data from `obj`.
 
-**4. Custom Element**
+**4. Custom Elements**
 
-Enigmatic.js simplifies the process of defining custom elements with the `w.element(name, options)` function. It takes the following parameters:
+Use `w.e(name, fn = {}, style = {})` to register a custom element. The `fn` object can contain an `init` method and any event handlers (e.g. `click`). The optional `style` object applies inline styles when the element is attached.
 
-- `name` (string): The name of the custom element.
-- `options` (object): An object containing configuration options for the custom element.
-  - `onMount`: A function to be executed when the custom element is connected to the DOM.
-  - `beforeData`: A function to preprocess the data before rendering the template.
-  - `style`: A string containing CSS rules specific to the custom element.
-  - `template`: A string representing the HTML template for the custom element.
+**5. State and Reactivity**
 
-**5. State, Data, and Reactivity**
+- `w.state`: reactive storage backed by a `Proxy`. Updating a key automatically calls any element with a matching `data` attribute and a `set` method.
+- `w.stream(url, key)`: subscribe to an EventSource and populate `w.state[key]` with incoming data.
 
-Enigmatic.js introduces reactive state management with the `w.state` object. It is implemented using a Proxy to reactively update DOM elements when state changes. DOM elements with `data` attributes that match state keys will be automatically updated when the corresponding state changes.
+**6. Initialization**
 
-- `w.state`: An object acting as reactive state storage. Changes to this object trigger updates in associated DOM elements with matching `data` attributes.
-
-- `w.save(obj, name)`: Saves a JavaScript object to the local storage under the specified name.
-- `w.load(name)`: Loads a JavaScript object from local storage using the given name.
-- `w.get(url, options, transform, key)`: Fetches data from a remote URL using the `fetch` API. Transforms the fetched data using the optional `transform` function and updates the state with the specified `key`.
-- `w.stream(url, key)`: Sets up an EventSource to stream real-time data from the specified URL and updates the state with the specified `key`.
-
-**6. Startup**
-
-Enigmatic.js provides the `w.start()` function to kickstart the library and process elements on the page with special attributes like `fetch`, `immediate`, and `stream`.
+The library runs automatically after loading. It enhances all `<div>` elements with support for the `fetch` attribute which loads JSON and renders it using their inner template.
 
 **7. Global Object**
 
-The code creates a global object `w` that holds all the utility functions and state management features.
+All helper functions are attached to the global object `w` as well as directly on `window` for convenience.
 
 **8. Usage Example**
-
-To use Enigmatic.js, include the script in your HTML file and call its functions as needed. For example:
 
 ```html
 <script src="unpkg.com/enigmatic"></script>
 <script>
-  // Perform custom element registration
-  w.element('custom-element', {
-    template: '<div>{_key_}: {_val_}</div>',
+  e('custom-element', {
+    init: e => e.innerHTML = 'ready',
+    click: ev => console.log('clicked')
   });
 
-  // Initialize Enigmatic.js
   (async () => {
-    await w.start();
-    w.state.exampleData = { key1: 'value1', key2: 'value2' };
+    await ready();
+    w.state.example = { key1: 'value1', key2: 'value2' };
   })();
 </script>
 ```


### PR DESCRIPTION
## Summary
- fix README to match library implementation

## Testing
- `npm test` *(fails: Cannot find module 'test.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_68458cbef28c8327b5dd010f7e1e2342