### PR TITLE
Fix test-fetch custom element

### DIFF
--- a/enigmatic.js
+++ b/enigmatic.js
@@ -71,6 +71,15 @@ w.state = new Proxy({}, {
   }
 })
 
+w.get = async (url, opts = {}, transform, key) => {
+  const res = await fetch(url, opts)
+  if (!res.ok) throw Error(`Could not fetch ${url}`)
+  let data = await res.json()
+  if (transform) data = transform(data)
+  if (key) w.state[key] = data
+  return data
+}
+
 w.stream = async (url, key) => {
   const ev = new EventSource(url)
   ev.onmessage = (ev) => {

--- a/tests/test-fetch.html
+++ b/tests/test-fetch.html
@@ -17,9 +17,9 @@
 
 <!-- Component -->
 <script>
-    element('my-c', {
+    e('my-c', {
         onmount: e=>e.style.border='1px solid black',
-        template: 'is: {gender}', 
+        template: 'is: {gender}',
         style: 'color:red'})
 </script>
 


### PR DESCRIPTION
## Summary
- implement global `get` helper
- use new `e()` shorthand in test-fetch example

## Testing
- `npm test` *(fails: Cannot find module 'test.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_68458da82fa483278080aff9baa34d78